### PR TITLE
Feat: 포인트 서비스 정책 추가 및 리팩토링 - 2

### DIFF
--- a/src/main/java/io/hhplus/tdd/ApiControllerAdvice.java
+++ b/src/main/java/io/hhplus/tdd/ApiControllerAdvice.java
@@ -11,4 +11,9 @@ class ApiControllerAdvice extends ResponseEntityExceptionHandler {
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
         return ResponseEntity.status(500).body(new ErrorResponse("500", "에러가 발생했습니다."));
     }
+
+    @ExceptionHandler(value = RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleRunTimeException(RuntimeException e) {
+        return ResponseEntity.status(500).body(new ErrorResponse("500", e.getMessage()));
+    }
 }

--- a/src/main/java/io/hhplus/tdd/point/PointValidator.java
+++ b/src/main/java/io/hhplus/tdd/point/PointValidator.java
@@ -1,8 +1,16 @@
 package io.hhplus.tdd.point;
 
+import static io.hhplus.tdd.point.PointService.MAXIMUM_POINT;
+
 public class PointValidator {
+
+    /**
+     * 포인트는 null 혹은 음수가 될 수 없으며 100만 이하의 포인트만 거래(충전/사용) 가능합니다.
+     * @param point
+     */
     public static void validate(Long point) {
         if (point == null) throw new RuntimeException("point can not be null.");
         if (point < 0) throw new RuntimeException("point can not be negative.");
+        if (point > MAXIMUM_POINT) throw new RuntimeException(String.format("you can just dael below or equal %d point at a once", MAXIMUM_POINT));
     }
 }

--- a/src/test/java/io/hhplus/tdd/point/PointServiceUnitTest.java
+++ b/src/test/java/io/hhplus/tdd/point/PointServiceUnitTest.java
@@ -11,7 +11,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Random;
 
+import static io.hhplus.tdd.point.PointService.MAXIMUM_POINT;
 import static io.hhplus.tdd.point.TransactionType.CHARGE;
 import static java.lang.System.currentTimeMillis;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -96,8 +98,10 @@ class PointServiceUnitTest {
     @DisplayName("실패 케이스 - [정책] 포인트 최대 잔고 초과")
     void maximumPointTest() {
         // given
-        long overMaximum = Long.MAX_VALUE;
+        pointService.chargePoint(1L, 1L);
+        long overMaximum = MAXIMUM_POINT;
 
+        // when & then
         assertThatThrownBy(() -> pointService.chargePoint(1L, overMaximum))
                 .isInstanceOf(OutOfMaximumPointException.class);
     }
@@ -125,7 +129,7 @@ class PointServiceUnitTest {
     @DisplayName("실패 케이스 - [정책] 포인트 잔고 부족")
     void minusPointTest() {
         // given
-        long point = Long.MAX_VALUE;
+        long point = new Random().nextLong(MAXIMUM_POINT);
 
         assertThatThrownBy(() -> pointService.reducePoint(1L, point))
                 .isInstanceOf(MinusPointException.class);

--- a/src/test/java/io/hhplus/tdd/point/PointValidatorTest.java
+++ b/src/test/java/io/hhplus/tdd/point/PointValidatorTest.java
@@ -1,12 +1,39 @@
 package io.hhplus.tdd.point;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.Random;
+
+import static io.hhplus.tdd.point.PointService.MAXIMUM_POINT;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PointValidatorTest {
 
+    /**
+     * 정상 범주의 포인트를 사용하는 케이스 검증
+     */
+    @Test
+    @DisplayName("정상적인 포인트인 경우")
+    void normal() {
+        // given
+        long givenPoint = new Random().nextLong(MAXIMUM_POINT);
+
+        // when
+        PointValidator.validate(givenPoint);
+
+        // then
+        assertThat(givenPoint)
+                .isNotNull()
+                .isGreaterThan(0)
+                .isLessThanOrEqualTo(MAXIMUM_POINT);
+    }
+
+    /**
+     * 거래하는 포인트가 null인 경우 이를 검증하는 테스트
+     */
     @Test
     @DisplayName("Null인 경우")
     void caseNull() {
@@ -14,10 +41,23 @@ class PointValidatorTest {
         assertThatThrownBy(() -> PointValidator.validate(givenPoint)).isInstanceOf(RuntimeException.class);
     }
 
+    /**
+     * 거래하는 포인트가 음수인 경우 이를 검증하는 테스트
+     */
     @Test
     @DisplayName("음수인 경우")
     void caseNegative() {
         Long givenPoint = -1L;
+        assertThatThrownBy(() -> PointValidator.validate(givenPoint)).isInstanceOf(RuntimeException.class);
+    }
+
+    /**
+     * 최대 충전잔고를 초과하는 포인트를 거래하려고하는 경우 검증
+     */
+    @Test
+    @DisplayName("최대거래 포인트")
+    void overMaximum() {
+        Long givenPoint = new Random().nextLong(MAXIMUM_POINT + 1L, Long.MAX_VALUE);
         assertThatThrownBy(() -> PointValidator.validate(givenPoint)).isInstanceOf(RuntimeException.class);
     }
 }


### PR DESCRIPTION
### 변경사항
- 비즈니스 로직 리팩토링
  - 포인트 관리(충전/사용) 시 누락되어 있던 기능 추가 (PointHistoryTable에 이력삽입)
  - 포인트 관리 로직에 사용자 별로 동기화 될 수 있도록 동시성 제어 로직 수정
     -> ConcurrentHashMap을 활용하여 사용자별 Lock 관리
- 정책 추가
  - 포인트 관리에 대한 정책 추가 (최대 잔고 이하의 포인트만 사용할 수 있도록 처리)
- RuntimeException 핸들러 추가

### 리뷰 포인트
- 동시성 제어관련 로직은 PointService.java에서 구현합니다.
  - 사용자별로 동기화처리하는 로직과 관련하여 리뷰 부탁드립니다.