### PR TITLE
Feat: 포인트 서비스 정책 추가 및 리팩토링 - 2

### DIFF
--- a/src/main/java/io/hhplus/tdd/ApiControllerAdvice.java
+++ b/src/main/java/io/hhplus/tdd/ApiControllerAdvice.java
@@ -11,4 +11,9 @@ class ApiControllerAdvice extends ResponseEntityExceptionHandler {
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
         return ResponseEntity.status(500).body(new ErrorResponse("500", "에러가 발생했습니다."));
     }
+
+    @ExceptionHandler(value = RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleRunTimeException(RuntimeException e) {
+        return ResponseEntity.status(500).body(new ErrorResponse("500", e.getMessage()));
+    }
 }

--- a/src/main/java/io/hhplus/tdd/point/PointValidator.java
+++ b/src/main/java/io/hhplus/tdd/point/PointValidator.java
@@ -1,8 +1,16 @@
 package io.hhplus.tdd.point;
 
+import static io.hhplus.tdd.point.PointService.MAXIMUM_POINT;
+
 public class PointValidator {
+
+    /**
+     * 포인트는 null 혹은 음수가 될 수 없으며 100만 이하의 포인트만 거래(충전/사용) 가능합니다.
+     * @param point
+     */
     public static void validate(Long point) {
         if (point == null) throw new RuntimeException("point can not be null.");
         if (point < 0) throw new RuntimeException("point can not be negative.");
+        if (point > MAXIMUM_POINT) throw new RuntimeException(String.format("you can just dael below or equal %d point at a once", MAXIMUM_POINT));
     }
 }

--- a/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
@@ -1,0 +1,202 @@
+package io.hhplus.tdd.point;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+
+import static java.util.concurrent.CompletableFuture.runAsync;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.annotation.DirtiesContext.MethodMode.BEFORE_METHOD;
+
+/**
+ * PointService class Integration Test
+ */
+@SpringBootTest
+class PointServiceTest {
+
+    @Autowired
+    private PointService pointService;
+
+    /**
+     * 동시에 여러 요청이 들어오더라도 하나의 요청씩 제어되는지 확인하는 테스트
+     */
+    @Test
+    @DisplayName("단일 사용자 대상")
+    @DirtiesContext(methodMode = BEFORE_METHOD) // 테스트의 격리를 위해 사용
+    void soloUser() throws ExecutionException, InterruptedException {
+        //given
+        pointService.chargePoint(1L, 1000);
+
+        CompletableFuture<Void> allTask = CompletableFuture.allOf(
+                runAsync(() -> pointService.chargePoint(1L, 700)),
+                runAsync(() -> pointService.chargePoint(1L, 1000)),
+                runAsync(() -> pointService.chargePoint(1L, 400)),
+                runAsync(() -> pointService.chargePoint(1L, 500)),
+                runAsync(() -> pointService.reducePoint(1L, 500)),
+                runAsync(() -> pointService.reducePoint(1L, 400))
+        );
+
+        //when
+        allTask.join();
+
+        //then
+        UserPoint userPoint = pointService.getUserPoint(1L);
+        assertThat(userPoint.point()).isEqualTo(1000 + 1700);
+
+        // 참고용 로그
+        pointService.getPointHistory(1l).stream().filter(h -> h.id() > 1)
+                .sorted((a, b) -> (int)(a.id() - b.id()))
+                .forEach(System.out::println);
+        System.out.println("\nuserPoint = " + userPoint);
+    }
+
+    /**
+     * 동시에 여러 요청(무작위 순서)이 들어오더라도 사용자별로 요청 제어되는지 확인하는 테스트
+     */
+    @Test
+    @DisplayName("다중 사용자 대상 - shuffle")
+    @DirtiesContext(methodMode = BEFORE_METHOD) // 테스트의 격리를 위해 사용
+    void multipleUser() throws ExecutionException, InterruptedException {
+        //given
+        pointService.chargePoint(1L, 1000);
+        pointService.chargePoint(2L, 1000);
+
+        List<Runnable> tasks = new ArrayList<>();
+        tasks.addAll(Arrays.asList(
+            // user1
+            () -> pointService.chargePoint(1L, 700),
+            () -> pointService.chargePoint(1L, 400),
+            () -> pointService.chargePoint(1L, 500),
+            () -> pointService.reducePoint(1L, 500),
+            () -> pointService.reducePoint(1L, 400),
+            // user2
+            () -> pointService.chargePoint(2L, 300),
+            () -> pointService.chargePoint(2L, 400),
+            () -> pointService.chargePoint(2L, 500),
+            () -> pointService.reducePoint(2L, 300),
+            () -> pointService.reducePoint(2L, 400)
+        ));
+        
+        // 무작위 순서로 변경
+        Collections.shuffle(tasks);
+
+        CompletableFuture<Void> allTask =
+                CompletableFuture.allOf(
+                        tasks.stream().map(task -> runAsync(task)).toArray(CompletableFuture[]::new)
+                );
+
+        //when
+        allTask.thenRun(() -> System.out.println("[FINISH] Thread work"));
+        allTask.join();
+
+        //then
+        UserPoint userPoint1 = pointService.getUserPoint(1L);
+        UserPoint userPoint2 = pointService.getUserPoint(2L);
+        assertThat(userPoint1.point()).isEqualTo(1000 + 700);
+        assertThat(userPoint2.point()).isEqualTo(1000 + 500);
+
+        // 참고용 로그
+        pointService.getPointHistory(1l).forEach(System.out::println);
+        pointService.getPointHistory(2l).forEach(System.out::println);
+    }
+
+    /**
+     * 모든 요청을 동기화하는 것이 아니라 사용자별로 동기화 처리가 정상적으로 되는지 확인하는 테스트
+     * 예) 사용자1이 요청하면 이후 사용자1의 정보로 오는 요청은 동기화 처리되어 Lock이 걸리지만
+     *     다른 사용자 (사용자 2, 사용자3 ...)가 보낸 요청은 Lock 처리가 되지 않는다.
+     */
+    @Test
+    @DisplayName("다중 사용자 - 사용자 간 작업분리")
+    @DirtiesContext(methodMode = BEFORE_METHOD) // 테스트의 격리를 위해 사용
+    void isolatedUserTest() {
+        //given
+        int numberOfUsers = 5;
+        int operationCountPerUser = 10;
+        long chargeAmount = new Random().nextLong(100, 301);
+        Map<Long, List<Long>> operationTimesPerUser = new ConcurrentHashMap<>();
+        List<CompletableFuture<Void>> allTasks = new ArrayList<>();
+
+        // when
+        initializeTasksWith(numberOfUsers, operationCountPerUser, chargeAmount, operationTimesPerUser, allTasks);
+        CompletableFuture.allOf(allTasks.toArray(new CompletableFuture[0])).join();
+
+        // then
+        for (long userId=1; userId<=numberOfUsers; userId++) {
+            List<Long> operationTimes = operationTimesPerUser.get(userId);
+
+            // 참고용 로그 - 아래 로그를 확인하면 각 사용자별 작업시간은 순차적으로 증가함을 확인할 수 있다.
+            System.out.printf("user-%d (ms): ", userId);
+            operationTimes.forEach(t -> System.out.print(t/1000000 + " "));
+            System.out.println();
+
+            if (userId > 1) {
+                List<Long> previousOperationTimes = operationTimesPerUser.get(userId - 1);
+                // 각 사용자별 첫 작업은 다른 사용자의 마지막 작업보다 소요시간이 더 작음을 검증
+                assertThat(operationTimes.get(0)).isLessThan(previousOperationTimes.get(previousOperationTimes.size() - 1));
+            }
+        }
+    }
+
+    private void initializeTasksWith(
+            int numberOfUsers,
+            int operationCountPerUser,
+            long chargeAmount,
+            Map<Long, List<Long>> operationTimesPerUser,
+            List<CompletableFuture<Void>> allTasks) {
+
+        for (long userId = 1; userId<= numberOfUsers; userId++) {
+            operationTimesPerUser.put(userId, Collections.synchronizedList(new ArrayList<>()));
+
+            long currentUserId = userId;
+            for (int i = 0; i < operationCountPerUser; i++) {
+                CompletableFuture<Void> task = runAsync(() -> {
+                    long start = System.nanoTime();
+                    pointService.chargePoint(currentUserId, chargeAmount);
+                    long end = System.nanoTime();
+
+                    operationTimesPerUser.get(currentUserId).add(end - start);
+                });
+                allTasks.add(task);
+            }
+        }
+    }
+
+    /**
+     * 회원가입되어있는 모든 사용자를 대상으로 포인트 조회가 가능하다.
+     */
+    @Test
+    @DisplayName("임의의 사용자에 대한 포인트 조회")
+    void findPointForAnyone() {
+        // given
+        long chosenUserId = new Random().nextLong(Long.MAX_VALUE - 1) + 1L;
+
+        // when
+        UserPoint userPoint = pointService.getUserPoint(chosenUserId);
+
+        // then
+        assertThat(userPoint.point()).isGreaterThanOrEqualTo(0L);
+    }
+
+    /**
+     * 회원가입되어있는 모든 사용자를 대상으로 포인트 충전/사용 이력 조회가 가능하다.
+     */
+    @Test
+    @DisplayName("임의의 사용자에 대한 포인트 이력 조회")
+    void findPointHistoryForAnyone() {
+        // given
+        long chosenUserId = new Random().nextLong(Long.MAX_VALUE - 1) + 1L;
+
+        // when
+        List<PointHistory> pointHistory = pointService.getPointHistory(chosenUserId);
+
+        // then
+        assertThat(pointHistory.size()).isGreaterThanOrEqualTo(0);
+    }
+}

--- a/src/test/java/io/hhplus/tdd/point/PointServiceUnitTest.java
+++ b/src/test/java/io/hhplus/tdd/point/PointServiceUnitTest.java
@@ -11,7 +11,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Random;
 
+import static io.hhplus.tdd.point.PointService.MAXIMUM_POINT;
 import static io.hhplus.tdd.point.TransactionType.CHARGE;
 import static java.lang.System.currentTimeMillis;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -96,8 +98,10 @@ class PointServiceUnitTest {
     @DisplayName("실패 케이스 - [정책] 포인트 최대 잔고 초과")
     void maximumPointTest() {
         // given
-        long overMaximum = Long.MAX_VALUE;
+        pointService.chargePoint(1L, 1L);
+        long overMaximum = MAXIMUM_POINT;
 
+        // when & then
         assertThatThrownBy(() -> pointService.chargePoint(1L, overMaximum))
                 .isInstanceOf(OutOfMaximumPointException.class);
     }
@@ -125,7 +129,7 @@ class PointServiceUnitTest {
     @DisplayName("실패 케이스 - [정책] 포인트 잔고 부족")
     void minusPointTest() {
         // given
-        long point = Long.MAX_VALUE;
+        long point = new Random().nextLong(MAXIMUM_POINT);
 
         assertThatThrownBy(() -> pointService.reducePoint(1L, point))
                 .isInstanceOf(MinusPointException.class);

--- a/src/test/java/io/hhplus/tdd/point/PointValidatorTest.java
+++ b/src/test/java/io/hhplus/tdd/point/PointValidatorTest.java
@@ -1,12 +1,39 @@
 package io.hhplus.tdd.point;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.Random;
+
+import static io.hhplus.tdd.point.PointService.MAXIMUM_POINT;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PointValidatorTest {
 
+    /**
+     * 정상 범주의 포인트를 사용하는 케이스 검증
+     */
+    @Test
+    @DisplayName("정상적인 포인트인 경우")
+    void normal() {
+        // given
+        long givenPoint = new Random().nextLong(MAXIMUM_POINT);
+
+        // when
+        PointValidator.validate(givenPoint);
+
+        // then
+        assertThat(givenPoint)
+                .isNotNull()
+                .isGreaterThan(0)
+                .isLessThanOrEqualTo(MAXIMUM_POINT);
+    }
+
+    /**
+     * 거래하는 포인트가 null인 경우 이를 검증하는 테스트
+     */
     @Test
     @DisplayName("Null인 경우")
     void caseNull() {
@@ -14,10 +41,23 @@ class PointValidatorTest {
         assertThatThrownBy(() -> PointValidator.validate(givenPoint)).isInstanceOf(RuntimeException.class);
     }
 
+    /**
+     * 거래하는 포인트가 음수인 경우 이를 검증하는 테스트
+     */
     @Test
     @DisplayName("음수인 경우")
     void caseNegative() {
         Long givenPoint = -1L;
+        assertThatThrownBy(() -> PointValidator.validate(givenPoint)).isInstanceOf(RuntimeException.class);
+    }
+
+    /**
+     * 최대 충전잔고를 초과하는 포인트를 거래하려고하는 경우 검증
+     */
+    @Test
+    @DisplayName("최대거래 포인트")
+    void overMaximum() {
+        Long givenPoint = new Random().nextLong(MAXIMUM_POINT + 1L, Long.MAX_VALUE);
         assertThatThrownBy(() -> PointValidator.validate(givenPoint)).isInstanceOf(RuntimeException.class);
     }
 }


### PR DESCRIPTION
### 변경사항
- 비즈니스 로직 리팩토링
  - 포인트 관리(충전/사용) 시 누락되어 있던 기능 추가 (PointHistoryTable에 이력삽입)
  - 포인트 관리 로직에 사용자 별로 동기화 될 수 있도록 동시성 제어 로직 수정
     -> ConcurrentHashMap을 활용하여 사용자별 Lock 관리
- 정책 추가
  - 포인트 관리에 대한 정책 추가 (최대 잔고 이하의 포인트만 사용할 수 있도록 처리)
- RuntimeException 핸들러 추가

### 리뷰 포인트
- 동시성 제어관련 로직은 PointService.java에서 구현합니다.
  - 사용자별로 동기화처리하는 로직과 관련하여 리뷰 부탁드립니다.
- 통합테스트 (PointServiceTest#isolatedUserTest())에서 포인트 처리에 대한 동기화가 사용자별로 잘 되어있는지 확인하는 로직을 작성했는데, 정상적으로 테스트를 작성한건지 리뷰 부탁드립니다.